### PR TITLE
Fix execution on parent poms

### DIFF
--- a/src/main/java/io/avaje/inject/mojo/ModuleSPIMojo.java
+++ b/src/main/java/io/avaje/inject/mojo/ModuleSPIMojo.java
@@ -22,11 +22,8 @@ public class ModuleSPIMojo extends AbstractMojo {
   @Override
   public void execute() throws MojoExecutionException {
 
-
     if (Integer.getInteger("java.specification.version") < 24) {
-      getLog()
-          .error(
-              "This version of the avaje-provides-plugin only works on JDK 24 and up");
+      getLog().error("This version of the avaje-provides-plugin only works on JDK 24 and up");
       return;
     }
 
@@ -50,7 +47,9 @@ public class ModuleSPIMojo extends AbstractMojo {
       }
       return targetClasses;
     } catch (final Exception e) {
-      throw new MojoExecutionException("Failed to get compiled classes", e);
+      getLog().warn("Failed to get compiled classes", e);
+
+      return Set.of();
     }
   }
 }


### PR DESCRIPTION
Currently it seems that the plugin fails to work when the compiled classes aren't available (such as parent poms)